### PR TITLE
Fix junk characters in ap name and HTML page

### DIFF
--- a/flipper/flipper-evil-portal/evil_portal_app.c
+++ b/flipper/flipper-evil-portal/evil_portal_app.c
@@ -1,8 +1,6 @@
+#include <furi.h>
 #include "evil_portal_app_i.h"
 #include "helpers/evil_portal_storage.h"
-
-#include <furi.h>
-#include <furi_hal.h>
 
 static bool evil_portal_app_custom_event_callback(void* context, uint32_t event) {
     furi_assert(context);
@@ -36,6 +34,7 @@ Evil_PortalApp* evil_portal_app_alloc() {
     app->file_path = furi_string_alloc();
 
     app->gui = furi_record_open(RECORD_GUI);
+    app->storage = furi_record_open(RECORD_STORAGE);
 
     app->view_dispatcher = view_dispatcher_alloc();
 
@@ -84,7 +83,7 @@ Evil_PortalApp* evil_portal_app_alloc() {
 void evil_portal_app_free(Evil_PortalApp* app) {
     // save latest logs
     if(furi_string_utf8_length(app->portal_logs) > 0) {
-        write_logs(app->portal_logs);
+        write_logs(app->storage, app->portal_logs);
         furi_string_free(app->portal_logs);
     }
 
@@ -113,6 +112,7 @@ void evil_portal_app_free(Evil_PortalApp* app) {
 
     // Close records
     furi_record_close(RECORD_GUI);
+    furi_record_close(RECORD_STORAGE);
 
     furi_record_close(RECORD_DIALOGS);
     furi_string_free(app->file_path);

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -65,7 +65,10 @@ struct Evil_PortalApp {
     bool sent_html;
     bool sent_reset;
     int BAUDRATE;
-    char text_store[2][128 + 1];
+
+    // AP SSID length can be maximum 32.
+    // Make the buffer 33 to accommodate the terminator char.
+    char ap_name[33];
 };
 
 typedef enum {

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -16,6 +16,7 @@
 #include <gui/view_stack.h>
 #include <dialogs/dialogs.h>
 #include <cfw.h>
+#include <storage/storage.h>
 
 #define NUM_MENU_ITEMS (6)
 
@@ -34,6 +35,7 @@ struct Evil_PortalApp {
     Gui* gui;
     ViewDispatcher* view_dispatcher;
     SceneManager* scene_manager;
+    Storage* storage;
 
     FuriString* portal_logs;
     const char* command_queue[1];

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -64,9 +64,6 @@ struct Evil_PortalApp {
     bool sent_reset;
     int BAUDRATE;
     char text_store[2][128 + 1];
-
-    uint8_t* index_html;
-    uint8_t* ap_name;
 };
 
 typedef enum {

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -55,7 +55,7 @@ static int32_t uart_worker(void* context) {
                                         SET_AP_CMD,
                                         uart->app->command_queue[uart->app->command_index],
                                         strlen(SET_AP_CMD))) {
-                                uart->app->sent_ap = evil_portal_set_ap_name(uart->app->storage);
+                                uart->app->sent_ap = evil_portal_set_ap_name(uart->app->ap_name);
                             }
 
                             uart->app->command_index = 0;

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -55,9 +55,7 @@ static int32_t uart_worker(void* context) {
                                         SET_AP_CMD,
                                         uart->app->command_queue[uart->app->command_index],
                                         strlen(SET_AP_CMD))) {
-                                Storage* storage = evil_portal_open_storage();
-                                uart->app->sent_ap = evil_portal_set_ap_name(storage);
-                                evil_portal_close_storage();
+                                uart->app->sent_ap = evil_portal_set_ap_name(uart->app->storage);
                             }
 
                             uart->app->command_index = 0;
@@ -71,7 +69,7 @@ static int32_t uart_worker(void* context) {
                     }
 
                     if(furi_string_utf8_length(uart->app->portal_logs) > 4000) {
-                        write_logs(uart->app->portal_logs);
+                        write_logs(uart->app->storage, uart->app->portal_logs);
                         furi_string_reset(uart->app->portal_logs);
                     }
                 } else {
@@ -81,7 +79,7 @@ static int32_t uart_worker(void* context) {
                     }
 
                     if(furi_string_utf8_length(uart->app->portal_logs) > 4000) {
-                        write_logs(uart->app->portal_logs);
+                        write_logs(uart->app->storage, uart->app->portal_logs);
                         furi_string_reset(uart->app->portal_logs);
                     }
                 }

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -1,6 +1,7 @@
 #include "evil_portal_app_i.h"
 #include "evil_portal_uart.h"
 #include "helpers/evil_portal_storage.h"
+#include "helpers/evil_portal_commands.h"
 
 struct Evil_PortalUart {
     Evil_PortalApp* app;
@@ -54,20 +55,9 @@ static int32_t uart_worker(void* context) {
                                         SET_AP_CMD,
                                         uart->app->command_queue[uart->app->command_index],
                                         strlen(SET_AP_CMD))) {
-                                FuriString* out_data = furi_string_alloc();
-
-                                furi_string_cat(out_data, "setap=");
-                                furi_string_cat(out_data, (char*)uart->app->ap_name);
-
-                                evil_portal_uart_tx(
-                                    (uint8_t*)(furi_string_get_cstr(out_data)),
-                                    strlen(furi_string_get_cstr(out_data)));
-                                evil_portal_uart_tx((uint8_t*)("\n"), 1);
-
-                                uart->app->sent_ap = true;
-
-                                free(out_data);
-                                free(uart->app->ap_name);
+                                Storage* storage = evil_portal_open_storage();
+                                uart->app->sent_ap = evil_portal_set_ap_name(storage);
+                                evil_portal_close_storage();
                             }
 
                             uart->app->command_index = 0;

--- a/flipper/flipper-evil-portal/evil_portal_uart.h
+++ b/flipper/flipper-evil-portal/evil_portal_uart.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "furi_hal.h"
+#include "evil_portal_app.h"
 
 #define RX_BUF_SIZE (320)
 

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -32,7 +32,6 @@ bool evil_portal_set_html(Storage *storage, const char* path) {
     furi_assert(storage, "storage is null");
     furi_assert(path, "the html file path is null");
 
-    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
     evil_portal_uart_tx((uint8_t*) "sethtml=", 8);
 
     bool html_sent = send_file_over_uart(storage, path);
@@ -45,7 +44,6 @@ bool evil_portal_set_html(Storage *storage, const char* path) {
         evil_portal_uart_tx((uint8_t*) error_message, strlen(error_message));
     }
 
-    // Send the commands terminator.
     evil_portal_uart_tx((uint8_t*) "\n", 1);
 
     return true;
@@ -55,7 +53,6 @@ bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
     furi_assert(storage, "storage is null");
     furi_assert(ap_config_path, "the ap config path is null");
 
-    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
     evil_portal_uart_tx((uint8_t*) "setap=", 6);
 
     bool ap_name_sent = send_file_over_uart(storage, ap_config_path);
@@ -65,7 +62,6 @@ bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
         evil_portal_uart_tx((uint8_t*) default_name, strlen(default_name));
     }
 
-    // Send the commands terminator.
     evil_portal_uart_tx((uint8_t*) "\n", 1);
     return true;
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -1,0 +1,73 @@
+#include <stream/stream.h>
+#include <stream/buffered_file_stream.h>
+#include "../evil_portal_uart.h"
+
+#define PORTAL_FILE_DIRECTORY_PATH EXT_PATH("apps_data/evil_portal")
+#define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
+
+static const char TAG[] = "evil_portal_command";
+
+static bool send_file_over_uart(Storage *storage, const char* path) {
+    Stream *file_stream = buffered_file_stream_alloc(storage);
+    if (!buffered_file_stream_open(file_stream, path, FSAM_READ, FSOM_OPEN_EXISTING)) {
+        FURI_LOG_E(TAG, "Unable to open stream: %s", path);
+        // The stream should be closed also if the open fails.
+        buffered_file_stream_close(file_stream);
+        return false;
+    }
+
+    uint8_t read_buffer[128];
+    size_t to_read_bytes = stream_size(file_stream);
+
+    while(to_read_bytes > 0) {
+        size_t byte_read = stream_read(file_stream, read_buffer, sizeof read_buffer);
+        evil_portal_uart_tx(read_buffer, byte_read);
+
+        to_read_bytes -= byte_read;
+    }
+
+    buffered_file_stream_close(file_stream);
+
+    return true;
+}
+
+bool evil_portal_set_html(Storage *storage, const char* path) {
+    furi_assert(storage, "storage is null");
+    furi_assert(path, "the html file path is null");
+
+    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
+    evil_portal_uart_tx((uint8_t*) "sethtml=", 8);
+
+    bool html_sent = send_file_over_uart(storage, path);
+
+    if (!html_sent) {
+        char *error_message = "<b>Evil portal</b><br>Unable to read the html file.<br>"
+                              "Is the SD Card set up correctly? <br>See instructions @ "
+                              "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
+                              "Under the 'Install pre-built app on the flipper' section.";
+        evil_portal_uart_tx((uint8_t*) error_message, strlen(error_message));
+    }
+
+    // Send the commands terminator.
+    evil_portal_uart_tx((uint8_t*) "\n", 1);
+
+    return true;
+}
+
+bool evil_portal_set_ap_name(Storage *storage) {
+    furi_assert(storage, "storage is null");
+
+    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
+    evil_portal_uart_tx((uint8_t*) "setap=", 6);
+
+    bool ap_name_sent = send_file_over_uart(storage, EVIL_PORTAL_AP_SAVE_PATH);
+
+    if (!ap_name_sent) {
+        char *default_name = "Evil Portal";
+        evil_portal_uart_tx((uint8_t*) default_name, strlen(default_name));
+    }
+
+    // Send the commands terminator.
+    evil_portal_uart_tx((uint8_t*) "\n", 1);
+    return true;
+}

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -2,10 +2,7 @@
 #include <stream/buffered_file_stream.h>
 #include "../evil_portal_uart.h"
 
-#define PORTAL_FILE_DIRECTORY_PATH EXT_PATH("apps_data/evil_portal")
-#define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
-
-static const char TAG[] = "evil_portal_command";
+#define TAG "evil_portal_command"
 
 static bool send_file_over_uart(Storage *storage, const char* path) {
     Stream *file_stream = buffered_file_stream_alloc(storage);
@@ -54,13 +51,14 @@ bool evil_portal_set_html(Storage *storage, const char* path) {
     return true;
 }
 
-bool evil_portal_set_ap_name(Storage *storage) {
+bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
     furi_assert(storage, "storage is null");
+    furi_assert(ap_config_path, "the ap config path is null");
 
     // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
     evil_portal_uart_tx((uint8_t*) "setap=", 6);
 
-    bool ap_name_sent = send_file_over_uart(storage, EVIL_PORTAL_AP_SAVE_PATH);
+    bool ap_name_sent = send_file_over_uart(storage, ap_config_path);
 
     if (!ap_name_sent) {
         char *default_name = "Evil Portal";

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -53,7 +53,7 @@ bool evil_portal_set_ap_name(const char* ap_name) {
     furi_assert(ap_name, "the ap name is null");
 
     evil_portal_uart_tx((uint8_t*)"setap=", 6);
-    evil_portal_uart_tx((uint8_t*) ap_name, strlen(ap_name));
+    evil_portal_uart_tx((uint8_t*)ap_name, strlen(ap_name));
     evil_portal_uart_tx((uint8_t*)"\n", 1);
 
     return true;

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -49,19 +49,12 @@ bool evil_portal_set_html(Storage* storage, const char* path) {
     return true;
 }
 
-bool evil_portal_set_ap_name(Storage* storage, const char* ap_config_path) {
-    furi_assert(storage, "storage is null");
-    furi_assert(ap_config_path, "the ap config path is null");
+bool evil_portal_set_ap_name(const char* ap_name) {
+    furi_assert(ap_name, "the ap name is null");
 
     evil_portal_uart_tx((uint8_t*)"setap=", 6);
-
-    bool ap_name_sent = send_file_over_uart(storage, ap_config_path);
-
-    if(!ap_name_sent) {
-        char* default_name = "Evil Portal";
-        evil_portal_uart_tx((uint8_t*)default_name, strlen(default_name));
-    }
-
+    evil_portal_uart_tx((uint8_t*) ap_name, strlen(ap_name));
     evil_portal_uart_tx((uint8_t*)"\n", 1);
+
     return true;
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -4,9 +4,9 @@
 
 #define TAG "evil_portal_command"
 
-static bool send_file_over_uart(Storage *storage, const char* path) {
-    Stream *file_stream = buffered_file_stream_alloc(storage);
-    if (!buffered_file_stream_open(file_stream, path, FSAM_READ, FSOM_OPEN_EXISTING)) {
+static bool send_file_over_uart(Storage* storage, const char* path) {
+    Stream* file_stream = buffered_file_stream_alloc(storage);
+    if(!buffered_file_stream_open(file_stream, path, FSAM_READ, FSOM_OPEN_EXISTING)) {
         FURI_LOG_E(TAG, "Unable to open stream: %s", path);
         // The stream should be closed also if the open fails.
         buffered_file_stream_close(file_stream);
@@ -28,40 +28,40 @@ static bool send_file_over_uart(Storage *storage, const char* path) {
     return true;
 }
 
-bool evil_portal_set_html(Storage *storage, const char* path) {
+bool evil_portal_set_html(Storage* storage, const char* path) {
     furi_assert(storage, "storage is null");
     furi_assert(path, "the html file path is null");
 
-    evil_portal_uart_tx((uint8_t*) "sethtml=", 8);
+    evil_portal_uart_tx((uint8_t*)"sethtml=", 8);
 
     bool html_sent = send_file_over_uart(storage, path);
 
-    if (!html_sent) {
-        char *error_message = "<b>Evil portal</b><br>Unable to read the html file.<br>"
+    if(!html_sent) {
+        char* error_message = "<b>Evil portal</b><br>Unable to read the html file.<br>"
                               "Is the SD Card set up correctly? <br>See instructions @ "
                               "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
                               "Under the 'Install pre-built app on the flipper' section.";
-        evil_portal_uart_tx((uint8_t*) error_message, strlen(error_message));
+        evil_portal_uart_tx((uint8_t*)error_message, strlen(error_message));
     }
 
-    evil_portal_uart_tx((uint8_t*) "\n", 1);
+    evil_portal_uart_tx((uint8_t*)"\n", 1);
 
     return true;
 }
 
-bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
+bool evil_portal_set_ap_name(Storage* storage, const char* ap_config_path) {
     furi_assert(storage, "storage is null");
     furi_assert(ap_config_path, "the ap config path is null");
 
-    evil_portal_uart_tx((uint8_t*) "setap=", 6);
+    evil_portal_uart_tx((uint8_t*)"setap=", 6);
 
     bool ap_name_sent = send_file_over_uart(storage, ap_config_path);
 
-    if (!ap_name_sent) {
-        char *default_name = "Evil Portal";
-        evil_portal_uart_tx((uint8_t*) default_name, strlen(default_name));
+    if(!ap_name_sent) {
+        char* default_name = "Evil Portal";
+        evil_portal_uart_tx((uint8_t*)default_name, strlen(default_name));
     }
 
-    evil_portal_uart_tx((uint8_t*) "\n", 1);
+    evil_portal_uart_tx((uint8_t*)"\n", 1);
     return true;
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -1,19 +1,18 @@
 #pragma once
 
 /**
- * Sends the provided evil portal index file to the ESP32.
- * @param storage - Storage instance.
- * @param path - Path of the index that will be sent to the ESP32.
- * @return Returns true if the file has been sent correctly, false otherwise.
+ * Sends the specified evil portal index file to the ESP32.
+ * @param storage - The storage instance to use.
+ * @param path - The path of the index file that will be sent to the ESP32.
+ * @return Returns true if the file has been sent successfully, false otherwise.
  */
 bool evil_portal_set_html(Storage *storage, const char *path);
 
 /**
- * Reads the access point name from the storage and then send it to the
- * ESP32.
- * @param storage - Storage instance.
- * @param ap_config_path - Path of the configuration file that contains the ap name
- * that will be sent to the ESP32.
- * @return Returns true if ap name has been sent to correctly, false otherwise.
+ * Reads the access point name from the storage and sends it to the ESP32.
+ * @param storage - The storage instance to use.
+ * @param ap_config_path - The path of the configuration file that contains the access point (AP) name
+ * to be sent to the ESP32.
+ * @return Returns true if the AP name has been sent correctly, false otherwise.
  */
 bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -6,12 +6,14 @@
  * @param path - Path of the index that will be sent to the ESP32.
  * @return Returns true if the file has been sent correctly, false otherwise.
  */
-bool evil_portal_set_html(Storage *storage, const char* path);
+bool evil_portal_set_html(Storage *storage, const char *path);
 
 /**
  * Reads the access point name from the storage and then send it to the
  * ESP32.
  * @param storage - Storage instance.
+ * @param ap_config_path - Path of the configuration file that contains the ap name
+ * that will be sent to the ESP32.
  * @return Returns true if ap name has been sent to correctly, false otherwise.
  */
-bool evil_portal_set_ap_name(Storage *storage);
+bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/**
+ * Sends the provided evil portal index file to the ESP32.
+ * @param storage - Storage instance.
+ * @param path - Path of the index that will be sent to the ESP32.
+ * @return Returns true if the file has been sent correctly, false otherwise.
+ */
+bool evil_portal_set_html(Storage *storage, const char* path);
+
+/**
+ * Reads the access point name from the storage and then send it to the
+ * ESP32.
+ * @param storage - Storage instance.
+ * @return Returns true if ap name has been sent to correctly, false otherwise.
+ */
+bool evil_portal_set_ap_name(Storage *storage);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -6,7 +6,7 @@
  * @param path - The path of the index file that will be sent to the ESP32.
  * @return Returns true if the file has been sent successfully, false otherwise.
  */
-bool evil_portal_set_html(Storage *storage, const char *path);
+bool evil_portal_set_html(Storage* storage, const char* path);
 
 /**
  * Reads the access point name from the storage and sends it to the ESP32.
@@ -15,4 +15,4 @@ bool evil_portal_set_html(Storage *storage, const char *path);
  * to be sent to the ESP32.
  * @return Returns true if the AP name has been sent correctly, false otherwise.
  */
-bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path);
+bool evil_portal_set_ap_name(Storage* storage, const char* ap_config_path);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -9,10 +9,8 @@
 bool evil_portal_set_html(Storage* storage, const char* path);
 
 /**
- * Reads the access point name from the storage and sends it to the ESP32.
- * @param storage - The storage instance to use.
- * @param ap_config_path - The path of the configuration file that contains the access point (AP) name
- * to be sent to the ESP32.
+ * Sets the access point name that will be created by the ESP32.
+ * @param ap_name - The access point (AP) name to be sent to the ESP32.
  * @return Returns true if the AP name has been sent correctly, false otherwise.
  */
-bool evil_portal_set_ap_name(Storage* storage, const char* ap_config_path);
+bool evil_portal_set_ap_name(const char* ap_name);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -31,7 +31,8 @@ void evil_portal_read_ap_name(void* context) {
     if(storage_common_stat(storage, EVIL_PORTAL_AP_SAVE_PATH, &fi) == FSE_OK) {
         File* ap_name = storage_file_alloc(storage);
         if(storage_file_open(ap_name, EVIL_PORTAL_AP_SAVE_PATH, FSAM_READ, FSOM_OPEN_EXISTING)) {
-            uint16_t now_read = storage_file_read(ap_name, app->ap_name, (uint16_t)sizeof(app->ap_name) - 1);
+            uint16_t now_read =
+                storage_file_read(ap_name, app->ap_name, (uint16_t)sizeof(app->ap_name) - 1);
             app->ap_name[now_read] = '\0';
         }
         storage_file_close(ap_name);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -1,10 +1,10 @@
 #include "evil_portal_storage.h"
 
-static Storage* evil_portal_open_storage() {
-    return furi_record_open(RECORD_STORAGE);
+Storage* evil_portal_open_storage() {
+  return furi_record_open(RECORD_STORAGE);
 }
 
-static void evil_portal_close_storage() {
+void evil_portal_close_storage() {
     furi_record_close(RECORD_STORAGE);
 }
 

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -1,47 +1,5 @@
 #include "evil_portal_storage.h"
 
-Storage* evil_portal_open_storage() {
-  return furi_record_open(RECORD_STORAGE);
-}
-
-void evil_portal_close_storage() {
-    furi_record_close(RECORD_STORAGE);
-}
-
-void evil_portal_read_index_html(void* context) {
-    Evil_PortalApp* app = context;
-    Storage* storage = evil_portal_open_storage();
-    FileInfo fi;
-
-    if(storage_common_stat(storage, EVIL_PORTAL_INDEX_SAVE_PATH, &fi) == FSE_OK) {
-        File* index_html = storage_file_alloc(storage);
-        if(storage_file_open(
-               index_html, EVIL_PORTAL_INDEX_SAVE_PATH, FSAM_READ, FSOM_OPEN_EXISTING)) {
-            app->index_html = malloc((size_t)fi.size);
-            uint8_t* buf_ptr = app->index_html;
-            size_t read = 0;
-            while(read < fi.size) {
-                size_t to_read = fi.size - read;
-                if(to_read > UINT16_MAX) to_read = UINT16_MAX;
-                uint16_t now_read = storage_file_read(index_html, buf_ptr, (uint16_t)to_read);
-                read += now_read;
-                buf_ptr += now_read;
-            }
-            free(buf_ptr);
-        }
-        storage_file_close(index_html);
-        storage_file_free(index_html);
-    } else {
-        char* html_error = "<b>Evil portal</b><br>Unable to read the html file.<br>"
-                           "Is the SD Card set up correctly? <br>See instructions @ "
-                           "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
-                           "Under the 'Install pre-built app on the flipper' section.";
-        app->index_html = (uint8_t*)html_error;
-    }
-
-    evil_portal_close_storage();
-}
-
 void evil_portal_replace_index_html(FuriString* path) {
     Storage* storage = evil_portal_open_storage();
     FS_Error error;
@@ -69,35 +27,6 @@ void evil_portal_create_html_folder_if_not_exists() {
     evil_portal_close_storage();
 }
 
-void evil_portal_read_ap_name(void* context) {
-    Evil_PortalApp* app = context;
-    Storage* storage = evil_portal_open_storage();
-    FileInfo fi;
-
-    if(storage_common_stat(storage, EVIL_PORTAL_AP_SAVE_PATH, &fi) == FSE_OK) {
-        File* ap_name = storage_file_alloc(storage);
-        if(storage_file_open(ap_name, EVIL_PORTAL_AP_SAVE_PATH, FSAM_READ, FSOM_OPEN_EXISTING)) {
-            app->ap_name = malloc((size_t)fi.size);
-            uint8_t* buf_ptr = app->ap_name;
-            size_t read = 0;
-            while(read < fi.size) {
-                size_t to_read = fi.size - read;
-                if(to_read > UINT16_MAX) to_read = UINT16_MAX;
-                uint16_t now_read = storage_file_read(ap_name, buf_ptr, (uint16_t)to_read);
-                read += now_read;
-                buf_ptr += now_read;
-            }
-            free(buf_ptr);
-        }
-        storage_file_close(ap_name);
-        storage_file_free(ap_name);
-    } else {
-        char* app_default = "Evil Portal";
-        app->ap_name = (uint8_t*)app_default;
-    }
-    evil_portal_close_storage();
-}
-
 void evil_portal_write_ap_name(void* context) {
     Evil_PortalApp* app = context;
     Storage* storage = evil_portal_open_storage();
@@ -111,7 +40,7 @@ void evil_portal_write_ap_name(void* context) {
     evil_portal_close_storage();
 }
 
-char* sequential_file_resolve_path(
+static char* sequential_file_resolve_path(
     Storage* storage,
     const char* dir,
     const char* prefix,
@@ -135,9 +64,7 @@ char* sequential_file_resolve_path(
     return strdup(file_path);
 }
 
-void write_logs(FuriString* portal_logs) {
-    Storage* storage = evil_portal_open_storage();
-
+void write_logs(Storage* storage, FuriString* portal_logs) {
     if(!storage_file_exists(storage, EVIL_PORTAL_LOG_SAVE_PATH)) {
         storage_simply_mkdir(storage, EVIL_PORTAL_LOG_SAVE_PATH);
     }
@@ -153,5 +80,4 @@ void write_logs(FuriString* portal_logs) {
     }
     storage_file_close(file);
     storage_file_free(file);
-    evil_portal_close_storage();
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
@@ -10,9 +10,7 @@
 #define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
 #define EVIL_PORTAL_LOG_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/logs"
 
-Storage* evil_portal_open_storage();
-void evil_portal_close_storage();
-void write_logs(FuriString* portal_logs);
+void write_logs(Storage* storage, FuriString* portal_logs);
 char* sequential_file_resolve_path(
     Storage* storage,
     const char* dir,

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
@@ -10,11 +10,8 @@
 #define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
 #define EVIL_PORTAL_LOG_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/logs"
 
-void evil_portal_read_index_html(void* context);
-void evil_portal_read_ap_name(void* context);
-void evil_portal_write_ap_name(void* context);
-void evil_portal_replace_index_html(FuriString* path);
-void evil_portal_create_html_folder_if_not_exists();
+Storage* evil_portal_open_storage();
+void evil_portal_close_storage();
 void write_logs(FuriString* portal_logs);
 char* sequential_file_resolve_path(
     Storage* storage,

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
@@ -10,9 +10,8 @@
 #define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
 #define EVIL_PORTAL_LOG_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/logs"
 
+void evil_portal_read_ap_name(void* context);
+void evil_portal_write_ap_name(void* context);
+void evil_portal_replace_index_html(Storage* storage, FuriString* path);
+void evil_portal_create_html_folder_if_not_exists(Storage* storage);
 void write_logs(Storage* storage, FuriString* portal_logs);
-char* sequential_file_resolve_path(
-    Storage* storage,
-    const char* dir,
-    const char* prefix,
-    const char* extension);

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -54,7 +54,7 @@ void evil_portal_scene_console_output_on_enter(void* context) {
             const char* help_msg = "Logs saved.\n\n";
             furi_string_cat_str(app->text_box_store, help_msg);
             app->text_box_store_strlen += strlen(help_msg);
-            write_logs(app->portal_logs);
+            write_logs(app->storage, app->portal_logs);
             furi_string_reset(app->portal_logs);
             if(app->show_stopscan_tip) {
                 const char* msg = "Press BACK to return\n";
@@ -105,9 +105,7 @@ void evil_portal_scene_console_output_on_enter(void* context) {
 
     if(app->is_command && app->selected_tx_string) {
         if(0 == strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
-            Storage *storage = evil_portal_open_storage();
-            app->sent_html = evil_portal_set_html(storage, EVIL_PORTAL_INDEX_SAVE_PATH);
-            evil_portal_close_storage();
+            app->sent_html = evil_portal_set_html(app->storage, EVIL_PORTAL_INDEX_SAVE_PATH);
         } else if(0 == strncmp(RESET_CMD, app->selected_tx_string, strlen(RESET_CMD))) {
             app->sent_html = false;
             app->sent_ap = false;

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -1,5 +1,6 @@
 #include "../evil_portal_app_i.h"
 #include "../helpers/evil_portal_storage.h"
+#include "../helpers/evil_portal_commands.h"
 
 void evil_portal_console_output_handle_rx_data_cb(uint8_t* buf, size_t len, void* context) {
     furi_assert(context);
@@ -104,22 +105,9 @@ void evil_portal_scene_console_output_on_enter(void* context) {
 
     if(app->is_command && app->selected_tx_string) {
         if(0 == strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
-            evil_portal_read_index_html(context);
-
-            FuriString* data = furi_string_alloc();
-            furi_string_cat(data, "sethtml=");
-            furi_string_cat(data, (char*)app->index_html);
-
-            evil_portal_uart_tx(
-                (uint8_t*)(furi_string_get_cstr(data)), strlen(furi_string_get_cstr(data)));
-            evil_portal_uart_tx((uint8_t*)("\n"), 1);
-
-            app->sent_html = true;
-
-            free(data);
-            free(app->index_html);
-
-            evil_portal_read_ap_name(context);
+            Storage *storage = evil_portal_open_storage();
+            app->sent_html = evil_portal_set_html(storage, EVIL_PORTAL_INDEX_SAVE_PATH);
+            evil_portal_close_storage();
         } else if(0 == strncmp(RESET_CMD, app->selected_tx_string, strlen(RESET_CMD))) {
             app->sent_html = false;
             app->sent_ap = false;

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_rename.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_rename.c
@@ -10,16 +10,14 @@ void evil_portal_text_input_callback(void* context) {
 void evil_portal_scene_rename_on_enter(void* context) {
     Evil_PortalApp* app = context;
     TextInput* text_input = app->text_input;
-    size_t enter_name_length = 25;
     evil_portal_read_ap_name(app);
     text_input_set_header_text(text_input, "AP Name/SSID");
-    strncpy(app->text_store[0], (char*)app->ap_name, enter_name_length);
     text_input_set_result_callback(
         text_input,
         evil_portal_text_input_callback,
         context,
-        app->text_store[0],
-        enter_name_length,
+        app->ap_name,
+        sizeof(app->ap_name),
         false);
     view_dispatcher_switch_to_view(app->view_dispatcher, Evil_PortalAppViewTextInput);
 }

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_select_html.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_select_html.c
@@ -19,7 +19,7 @@ void evil_portal_show_loading_popup(Evil_PortalApp* app, bool show) {
 void evil_portal_scene_select_html_on_enter(void* context) {
     Evil_PortalApp* app = context;
     DialogsFileBrowserOptions browser_options;
-    evil_portal_create_html_folder_if_not_exists();
+    evil_portal_create_html_folder_if_not_exists(app->storage);
 
     dialog_file_browser_set_basic_options(&browser_options, HTML_EXTENSION, &I_evil_portal_10px);
     browser_options.base_path = HTML_FOLDER;
@@ -35,7 +35,7 @@ void evil_portal_scene_select_html_on_enter(void* context) {
     if(success) {
         //Replace HTML File
         evil_portal_show_loading_popup(app, true);
-        evil_portal_replace_index_html(app->file_path);
+        evil_portal_replace_index_html(app->storage, app->file_path);
         evil_portal_show_loading_popup(app, false);
     }
 


### PR DESCRIPTION
This is a modified version of [PR #53](https://github.com/bigbrodude6119/flipper-zero-evil-portal/pull/53) to address the issue of displaying junk characters on the HTML page and the access point (AP) name.

Please note that this PR includes some changes not present in the original one, as this fork has merged some PRs that are still open in the original repository.